### PR TITLE
Fixes CMake exporting/packaging to ensure proper inclusion within ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,53 @@
 cmake_minimum_required(VERSION 3.15)
-project(xsens_public_sdk C CXX)
+project(xsens_public_sdk VERSION 0.0.1 LANGUAGES C CXX)
+
+# Set a default build type if none was specified
+set(default_build_type "RelWithDebInfo")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Packaging
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+# Generate <Package>Config.cmake
+configure_package_config_file(
+  "PackageConfig.cmake.in"
+  "${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
+
+# Generate <Package>Version.cmake
+write_basic_package_version_file(
+  "${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+  COMPONENT dev)
+
+# Generate <Package>Targets.cmake
+install(
+  EXPORT ${PROJECT_NAME}
+  FILE "${PROJECT_NAME}Targets.cmake"
+  NAMESPACE "${PROJECT_NAME}::"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+  COMPONENT dev)
 
 # Libraries
 add_subdirectory(xspublic)

--- a/PackageConfig.cmake.in
+++ b/PackageConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,8 +11,6 @@ add_executable( mti_recv
 target_link_libraries( mti_recv
 PUBLIC
   xscontroller
-  xscommon
-  xstypes
 )
 
 target_compile_options( mti_recv

--- a/xspublic/CMakeLists.txt
+++ b/xspublic/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(xspublic C CXX)
+project(xsens_public_sdk C CXX)
 
 add_subdirectory(xstypes)
 add_subdirectory(xscommon)

--- a/xspublic/xscommon/CMakeLists.txt
+++ b/xspublic/xscommon/CMakeLists.txt
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 3.15)
-project(xscommon C CXX)
-
 # ==============================================
 # Targets
 
@@ -42,13 +39,25 @@ PUBLIC
   cxx_std_17
 )
 
+# Create a pseudo-target that other targets (i.e. examples, tests) can depend
+# on and can also be provided as import-target by a package-file when building
+# those targets outside the regular build-tree (i.e. the installed tree)
+add_library(${PROJECT_NAME}::xscommon ALIAS xscommon)
+
 # ==============================================
 # Install
 
-install( FILES ${XSCOMMON_PUBLIC_HEADERS} DESTINATION include/xscommon )
+# Headers
+install( 
+  FILES ${XSCOMMON_PUBLIC_HEADERS} 
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xscommon
+  COMPONENT dev )
+
+# Binaries
 install(
   TARGETS xscommon
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+  EXPORT "${PROJECT_NAME}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT lib
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
 )

--- a/xspublic/xscommon/journaller.h
+++ b/xspublic/xscommon/journaller.h
@@ -295,7 +295,11 @@ inline static constexpr char const* jlStrippedPathFile(char const* a)
 #endif
 
 #ifndef _lint	//pclint defines this
-	#define JLIF(journal, level, todo)	do { if (journal && journal->logLevel(level)) { todo; } } while(0)
+	#ifdef HAVE_JOURNALLER
+		#define JLIF(journal, level, todo)	do { if (journal && journal->logLevel(level)) { todo; } } while(0)
+	#else
+		#define JLIF(...)	((void)0)
+	#endif
 #else
 	#define JLIF(...)	((void)0)
 #endif

--- a/xspublic/xscontroller/CMakeLists.txt
+++ b/xspublic/xscontroller/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.15)
-project(xscontroller C CXX)
+# ==============================================
+# Dependencies
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(LIBUSB REQUIRED libusb)
@@ -58,13 +58,25 @@ PUBLIC
   cxx_std_17
 )
 
+# Create a pseudo-target that other targets (i.e. examples, tests) can depend
+# on and can also be provided as import-target by a package-file when building
+# those targets outside the regular build-tree (i.e. the installed tree)
+add_library(${PROJECT_NAME}::xscontroller ALIAS xscontroller)
+
 # ==============================================
 # Install
 
-install( FILES ${XSCONTROLLER_PUBLIC_HEADERS} DESTINATION include/xscontroller )
+# Headers
+install( 
+  FILES ${XSCONTROLLER_PUBLIC_HEADERS} 
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xscontroller
+  COMPONENT dev )
+
+# Binaries
 install(
   TARGETS xscontroller
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+  EXPORT "${PROJECT_NAME}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT lib
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
 )

--- a/xspublic/xscontroller/CMakeLists.txt
+++ b/xspublic/xscontroller/CMakeLists.txt
@@ -48,7 +48,6 @@ PUBLIC
 
 target_compile_definitions(xscontroller
 PUBLIC
-    -DHAVE_JOURNALLER
     -DHAVE_LIBUSB
 )
 

--- a/xspublic/xstypes/CMakeLists.txt
+++ b/xspublic/xstypes/CMakeLists.txt
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 3.15)
-project(xstypes C CXX)
-
 # ==============================================
 # Targets
 
@@ -38,13 +35,25 @@ PUBLIC
   cxx_std_17
 )
 
+# Create a pseudo-target that other targets (i.e. examples, tests) can depend
+# on and can also be provided as import-target by a package-file when building
+# those targets outside the regular build-tree (i.e. the installed tree)
+add_library(${PROJECT_NAME}::xstypes ALIAS xstypes)
+
 # ==============================================
 # Install
 
-install( FILES ${XSTYPES_PUBLIC_HEADERS} DESTINATION include/xstypes )
+# Headers
+install( 
+  FILES ${XSTYPES_PUBLIC_HEADERS} 
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xstypes
+  COMPONENT dev )
+
+# Binaries
 install(
   TARGETS xstypes
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+  EXPORT "${PROJECT_NAME}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT lib
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
 )


### PR DESCRIPTION
Was having problems locating header files and libraries when including this as a dependency for a ROS2 node. 

These changes are yoinked from the CycloneDDS repo, which also structures itself as a non-ament, plain-cmake package.
https://github.com/eclipse-cyclonedds/cyclonedds/tree/master

In summary, this makes sure that the equivalent of a Find<MyPackage>.cmake module is generated and exported, such that `find_package(xsens_public_sdk)` works.

It also exports a top level target, so that the consuming package links against the included libraries using something like `xsens_public_sdk::xscontroller`.